### PR TITLE
Handling Other Snippet Line Formats

### DIFF
--- a/src/features/codeLens.ts
+++ b/src/features/codeLens.ts
@@ -56,8 +56,8 @@ export class CodeLens implements vscode.CodeLensProvider {
             if (vscode.workspace.getConfiguration("unityToolbox").get("codeLensForUnityEventMethods", true)) {
                 let url = this.document.lineAt(codeLens.range.start.line).text;
                 url = url.replace(/ /g, "")
-                url = url.replace(/void/g, "")
-                url = url.slice(0, -2);
+                url = url.replace(/(?:private)?void/g, "")
+                url = url.slice(0, url.indexOf('(') - url.length);
 
                 codeLens.command = {
                     title: "Unity Event",


### PR DESCRIPTION
Great feature for Unity snippets! I use an existing snippet extension called [Unity Code Snippets](https://marketplace.visualstudio.com/items?itemName=kleber-swf.unity-code-snippets) and the formatting of its lines causes some issues with your documentation URL generation. Specifically, your `slice` is hard-coded to your line format. This PR should fix that in case someone else wanted another snippet or format to their lines, but still wants a documentation codelens.

Have confirmed each format below has working links.

![image](https://user-images.githubusercontent.com/6425702/114322131-8b99bd80-9aec-11eb-8354-9eac9f8faf65.png)

