### PR TITLE
Added some useful features

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "configuration": {
       "title": "Unity Toolbox",
       "properties": {
-        "unityToolbox.bracketsStyle": {
+        "unityToolbox.codeSnippets.bracketsStyle": {
           "enum": [
             "new line",
             "same line, with space",
@@ -49,6 +49,33 @@
           ],
           "default": "new line",
           "description": "Changes how the first curly bracket is inserted in snippets."
+        },
+        "unityToolbox.codeSnippets.requiredClass": {
+          "enum": [
+            "MonoBehaviour or NetworkBehaviour",
+            "any derived class",
+            "any class"
+          ],
+          "default": "MonoBehaviour or NetworkBehaviour",
+          "description": "Enable code snippets in ..."
+        },
+        "unityToolbox.codeLens.requiredClass": {
+          "enum": [
+            "MonoBehaviour or NetworkBehaviour",
+            "any derived class",
+            "any class"
+          ],
+          "default": "MonoBehaviour or NetworkBehaviour",
+          "description": "Enable codeLens in ..."
+        },
+        "unityToolbox.hover.requiredClass": {
+          "enum": [
+            "MonoBehaviour or NetworkBehaviour",
+            "any derived class",
+            "any class"
+          ],
+          "default": "MonoBehaviour or NetworkBehaviour",
+          "description": "Enable hover in ..."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
           "default": "new line",
           "description": "Changes how the first curly bracket is inserted in snippets."
         },
+        "unityToolbox.codeSnippets.methodModifiers": {
+          "type": "string",
+          "default": "",
+          "description": "Add modifiers to the method snippets. The trailing whitespace is required.\ne.g. \"public \", \"protected virtual \""
+        },
         "unityToolbox.codeSnippets.requiredClass": {
           "enum": [
             "MonoBehaviour or NetworkBehaviour",

--- a/src/codeLens.ts
+++ b/src/codeLens.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, CodeLens, CodeLensProvider, Command, Position, ProviderResult, TextDocument } from 'vscode';
+import { CancellationToken, CodeLens, CodeLensProvider, Command, Position, ProviderResult, TextDocument, workspace } from 'vscode';
 import { parser } from './extension';
 
 export default class UnityMessageCodeLensProvider implements CodeLensProvider {
@@ -10,15 +10,15 @@ export default class UnityMessageCodeLensProvider implements CodeLensProvider {
             const line = lines[i];
 
             if (!parser.hasUnityMessage(line)) continue;
-            if (!parser.isInBehaviour(lines, i)) continue;
 
-            const behaviour = parser.findBehaviour(lines);
-            if (behaviour === undefined) continue;
-            const openingLine = parser.findOpeningBracket(lines, behaviour);
-            if (openingLine === undefined) continue;
+            const requiredClass = workspace.getConfiguration('unityToolbox').get('codeLens.requiredClass');
+            const baseClass = parser.getBaseClass(lines, i);
 
-            if (!parser.isLineOnBracketsLevel(lines, openingLine, i) && parser.findMethodsName(line) === undefined) continue;
-            // ^ is on the brackets level or method definition 
+            if (baseClass === undefined) continue;
+
+            if (requiredClass === "any derived class" && baseClass === "") continue;
+
+            if (requiredClass === "MonoBehaviour or NetworkBehaviour" && baseClass !== "MonoBehaviour" && baseClass !== "NetworkBehaviour") continue;
 
             let cmd: Command = {
                 command: "",

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, Hover, HoverProvider, Position, ProviderResult, TextDocument, Range } from "vscode";
+import { CancellationToken, Hover, HoverProvider, Position, ProviderResult, TextDocument, Range, workspace } from "vscode";
 import { parser } from "./extension";
 import * as messages from "./unity-messages.json";
 
@@ -7,8 +7,16 @@ export default class UnityMessageHoverProvider implements HoverProvider {
         const lines = doc.getText().split("\n");
         const line = lines[pos.line];
 
-        if (!parser.isInBehaviour(lines, pos.line)) return;
         if (!parser.hasUnityMessage(line)) return;
+
+        const requiredClass = workspace.getConfiguration("unityToolbox").get("hover.requiredClass");
+        const baseClass = parser.getBaseClass(lines, pos.line);
+
+        if (baseClass === undefined) return;
+
+        if (requiredClass === "any derived class" && baseClass === "") return;
+
+        if (requiredClass === "MonoBehaviour or NetworkBehaviour" && baseClass !== "MonoBehaviour" && baseClass !== "NetworkBehaviour") return;
 
         const name = parser.findMethodsName(line);
         if (name === undefined) return;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,6 +31,7 @@ export default class Parser {
     getBaseClass(lines: string[], thisLine: number): string | undefined {
         if (thisLine >= lines.length) return undefined;
 
+        // Find the closest opening bracket containing this line.
         let count = 0;
         let i = thisLine - 1;
         for (; i > 0; i--) {
@@ -39,23 +40,27 @@ export default class Parser {
             if (line.includes("{")) {
                 count += 1;
             }
-
             if (line.includes("}")) {
                 count -= 1;
             }
-
-            if (count === 1) {
+            if (count === 1) {  // Found
                 break;
             }
         }
 
-        let matchClass = new RegExp(/class\s*(.*?)[\s|\,|\{]/);
-        let matchBaseClass = new RegExp(/class.*:\s*(.*?)[\s|\,|\{]/);
+        // Match the class.
+        const matchClass = new RegExp(/class\s*(.*?)[\s|\,|\{]/);
+        const matchBaseClass = new RegExp(/class.*:\s*(.*?)[\s|\,|\{]/);
         for (; i > 0; i--) {
             const line = lines[i];
+
+            // If these characters are found, it's not a valid class.
             if (line.includes("\"") || line.includes("'") || line.includes(";") || line.includes("}"))
                 return undefined;
+
+            // Match the class definition.
             if (line.match(matchClass) != null) {
+                // Match the base class.
                 const matches = line.match(matchBaseClass);
                 return matches === null ? "" : matches[1];
             }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -23,6 +23,46 @@ export default class Parser {
     }
 
     /**
+     * Get the base class of the class that this line is in.
+     * @returns undefined if no valid class.
+     * @returns empty string if no base class.
+     * @returns the base class name.
+     */
+    getBaseClass(lines: string[], thisLine: number): string | undefined {
+        if (thisLine >= lines.length) return undefined;
+
+        let count = 0;
+        let i = thisLine - 1;
+        for (; i > 0; i--) {
+            const line = lines[i];
+
+            if (line.includes("{")) {
+                count += 1;
+            }
+
+            if (line.includes("}")) {
+                count -= 1;
+            }
+
+            if (count === 1) {
+                break;
+            }
+        }
+
+        let matchClass = new RegExp(/class\s*(.*?)[\s|\,|\{]/);
+        let matchBaseClass = new RegExp(/class.*:\s*(.*?)[\s|\,|\{]/);
+        for (; i > 0; i--) {
+            const line = lines[i];
+            if (line.includes("\"") || line.includes("'") || line.includes(";") || line.includes("}"))
+                return undefined;
+            if (line.match(matchClass) != null) {
+                const matches = line.match(matchBaseClass);
+                return matches === null ? "" : matches[1];
+            }
+        }
+    }
+
+    /**
      * Checks if there is a Unity message in a line.
      */
     hasUnityMessage(line: string): boolean {

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -28,6 +28,7 @@ export class UnityMessageSnippetsProvider implements CompletionItemProvider {
             item.documentation = msg.description;
 
             let snippet = applyBracketsStyle(msg.body, 0).join("\n");
+            snippet = applyModifiers(snippet);
             item.insertText = new SnippetString(snippet);
 
             items.push(item);
@@ -66,6 +67,11 @@ function applyBracketsStyle(body: string[], definitionLine: number): string[] {
     }
 
     return snippet;
+}
+
+function applyModifiers(snippet: string): string {
+    const modifiers = workspace.getConfiguration("unityToolbox").get("codeSnippets.methodModifiers");
+    return modifiers + snippet;
 }
 
 export class ScriptTemplatesSnippetsProvider implements CompletionItemProvider {


### PR DESCRIPTION
In use, I found some useful features that were not included, and this PR added some of them.

1. The features are not enabled in the class that is derived from MonoBehaviour. So check the base class name that current line belongs to, instead of checking if current line is in a MonoBehaviour. I've added settings to control these features will be enabled in which classes.
   This is still not the perfect solution, but it's better than before.

2. CodeLens was enabled for the local functions. This will be also fixed when use the base class check.

3. Some people prefer to add the access modifier, and there should also be a setting to configure it.
